### PR TITLE
Create Prometheus exporter for DDF metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/*
+.idea/*
+*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.6-alpine as base
+FROM base as builder
+
+# Get Dependencies
+COPY ./requirements.txt /
+RUN pip install --install-option="--prefix=/install" -r /requirements.txt
+
+# Set python path to include dependencies and src code
+ENV PYTHONPATH=/src:/install/lib/python3.6/site-packages:$PYTHONPATH
+
+COPY ddf_exporter.py /src/ddf_exporter.py
+COPY test/test_ddf_exporter.py /src/test_ddf_exporter.py
+RUN dos2unix /src/*
+RUN chmod 755 /src/*.py
+RUN python -m unittest /src/test_ddf_exporter.py
+
+# Build the production image
+FROM base
+
+COPY --from=builder /install /usr/local
+COPY --from=builder /src/ddf_exporter.py /app/
+RUN ln -s /app/ddf_exporter.py /usr/local/bin/ddf-exporter
+RUN chmod 755 /usr/local/bin/ddf-exporter
+
+ENTRYPOINT ["ddf-exporter"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+IMAGE_NAME=connexta/ddf_exporter
+GIT_BRANCH:=$(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,' 2>/dev/null)
+ifneq ($(GIT_BRANCH), master)
+	IMAGE_TAG=$(GIT_BRANCH)
+else
+	IMAGE_TAG=latest
+endif
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile .
+
+.PHONY: deploy
+deploy: build
+	docker push $(IMAGE_NAME):$(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,14 @@ else
 	IMAGE_TAG=latest
 endif
 
-.PHONY: build
-build:
+.PHONY: help
+help: ## Display help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)```
+
+.PHONY: image
+image: ## Create the docker image
 	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile .
 
-.PHONY: deploy
-deploy: build
+.PHONY: push
+push: image ## Push docker image
 	docker push $(IMAGE_NAME):$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# DDFexporter for Prometheus
+
+A prometheus exporter for the metrics endpoint in DDF.
+
+## Installation
+Configure your prometheus instance to scrape from this module.
+
+## Configuration options
+This exporter can be configured using environment variables, they are as follows:
+
+| Env variable      | Default           | Description  |
+| ------------- |:-------------:| -----:|
+| `BIND_PORT`| 9170 | The port for the exporter to bind to
+| `METRIC_PREFIX` | "ddf_" | What to prepend to all of the gathered metrics
+| `HOST_ADDRESS` | "https://localhost" | The address to gather metrics from. Please include the http:// or https://
+| `HOST_PORT` | 8993 | The port to gather metrics from
+| `METRIC_API_LOCATION` | "services/internal/metrics" | The path to the metrics endpoint
+| `SECURE` | "True" | Whether to use ssl for the connection. <br/> If true, you must point to a valid ca cert in the next parameter
+| `CA_CERT_PATH` | "/certs/ca.pem" | The path to the ca cert to be used during secure connections
+
+### Docker-compose example
+
+<details><summary>Click to expand</summary>
+<p>
+
+```
+...
+    ddfexporter:
+        build: ./
+        ports:
+          - 9170:9170
+   
+        environment:
+          BIND_PORT: 9170
+          HOST_ADDRESS: "https://localhost"
+          HOST_PORT: 8993
+          METRIC_PREFIX: "ddf_"
+          METRIC_API_LOCATION: "services/internal/metrics"
+          SECURE: "True"
+    
+        volumes:
+          - type: bind
+            source: ./cacert.pem
+            target: /cacerts/cert.pem
+...
+```
+
+</p>
+</details>
+

--- a/ddf_exporter.py
+++ b/ddf_exporter.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+from typing import Optional, Iterator
+from prometheus_client import start_http_server
+from prometheus_client.core import GaugeMetricFamily, REGISTRY
+
+import requests, sys, time, os, signal, re
+from requests import Timeout, TooManyRedirects
+
+
+class DDFCollector:
+
+    def __init__(self):
+
+        self.metric_prefix = os.getenv('METRIC_PREFIX', 'ddf_')
+        self.host = os.getenv('HOST_ADDRESS', 'https://localhost')
+        self.host_port = os.getenv('HOST_PORT', 8993)
+        self.metric_api_location = os.getenv('METRIC_API_LOCATION',
+                                             'services/internal/metrics')
+        self.secure = os.getenv('SECURE', "True")
+        self.ca_cert_path = os.getenv('CA_CERT_PATH', '/certs/ca.pem')
+
+        self.file_ext = '.json'
+
+        self.metric_endpoints = {}
+        self.metric_results = {}
+
+    # The collect method is used whenever a scrape request from prometheus activates this script.
+    def collect(self):
+        # get the endpoints
+        self.metric_endpoints = self.fetch_available_endpoints()
+
+        # fetch data from those endpoints
+        self.metric_results = self.populate_and_fetch_metrics(
+            self.metric_endpoints,
+            self.metric_prefix,
+            labels={'host': self.host})
+
+        # yield the data as metrics
+        for metric_name in self.metric_endpoints.keys():
+            yield self.metric_results[metric_name]
+
+    # If offset is less than 120, then there may be no record, as the server may still be collecting that info.
+    def _make_request(self, metric_name: str, offset: Optional[int] = 120) -> dict:
+        """
+        Sends a get request based on a specified metric, and then returns the json.
+
+        :param metric_name: The name of the metric, which will be used to lookup the corresponding endpoint
+        :param offset: From the present, how many seconds into the past to fetch data for that metric
+        :return: The dict/json representing the response
+        """
+
+        query_url = '{host}:{host_port}/{api_location}/'.format(
+            **{
+                'host': self.host,
+                'host_port': self.host_port,
+                'api_location': self.metric_api_location
+            })
+
+        # If no offset, then we only want the base url.
+        if offset is not None:
+            query_url += '{metric_endpoint}{file_ext}?dateOffset={offset}'.format(
+                **{
+                    'metric_endpoint': self.metric_endpoints.get(metric_name),
+                    'file_ext': self.file_ext,
+                    'offset': str(offset)
+                })
+
+        download = None
+        with requests.Session() as session:
+            try:
+                # User wants to operate insecurely, or the host is not an https request.
+                # Have to hardcode strings because dockerfiles cannot handle booleans
+                if self.secure == "False" or not query_url.startswith("https://"):
+                    download = session.get(query_url, verify=False)
+                    # shows a warning if using HTTPS, does not do so if using http.
+
+                # If user wants to operate securely and they provided a certificate in the certs directory.
+                elif self.secure == "True" and os.path.isfile(self.ca_cert_path):
+                    download = session.get(query_url, verify=self.ca_cert_path)
+
+                # If the user wants to operate securely but didn't provide a certificate, we can't get metrics.
+                else:
+                    raise FileNotFoundError(
+                        'Secure metric connections are enabled but could not locate cert.pem inside of cacerts directory. '
+                        'Either set environment variable SECURE to \"False\", or place a certificate at the path listed in the CA_CERT_PATH env variable.'
+                        'See readme for more details.'
+                    )
+
+            except requests.RequestException as e:
+                # DNS failure, refused connection, etc
+                print("Error: " + str(e))
+                return {}
+
+        return download.json()
+
+    def fetch_available_endpoints(self) -> dict:
+        """
+        Query the metrics endpoint to get available metrics, then process the result into a snake_case: camelCase
+        dictionary.
+
+        :return: a dict representing the snake_case: camelCase available endpoints
+        """
+        endpoints = list(self._make_request('', offset=None).keys())
+
+        available_endpoints = {}
+        for endpoint in endpoints:
+            available_endpoints[_camel_to_snake_case(endpoint)] = endpoint
+
+        return available_endpoints
+
+    def populate_and_fetch_metrics(self,
+                                   available_endpoints: dict,
+                                   prefix: str,
+                                   labels: Optional[dict] = None) -> dict:
+        """
+        Query each available endpoint, retrieve it's value/values at that time, and store it into a results dictionary.
+
+        :param available_endpoints: dictionary of snake_case: camelCase strings representing metric endpoints
+        :param prefix: the prefix to be prepended to all metrics generated by this exporter
+        :param labels: an optional set of tags for to include on the metrics
+        :return: a dictionary of metrics with their corresponding values as retrieved from the endpoint
+        """
+        metric_results = {}
+
+        if labels is None:
+            labels = {}
+
+        # for every available endpoint
+        for metric_name in available_endpoints.keys():
+
+            # Create an empty metric for that endpoint to hold its results
+            metric_results[metric_name] = GaugeMetricFamily(
+                prefix + metric_name, metric_name, labels=labels.keys())
+
+            # Call to that endpoint and add all of its datapoints to the results.
+            # Empty metrics are automatically hidden in prometheus, so an endpoint that responded
+            # without data doesn't present an issue.
+            for data_point in _json_to_metric_generator(self._make_request(metric_name)):
+                metric_results[metric_name].add_metric(labels=list(labels.values()), value=data_point['value'])
+
+        return metric_results
+
+
+def _json_to_metric_generator(json_response: dict) -> Iterator[dict]:
+    """
+    The returned JSON may or may not have multiple data rows, this helper function makes the results
+    iterable so that these multiple rows can be handled in a loop.
+
+    :param: json_response, a dict object representing the jason file. Its structure is:
+    {
+       "data":[
+          {
+             "value": flt,
+             "timestamp": str
+          },
+          {
+             "value": flt,
+             "timestamp": str
+          },
+          ...
+       ],
+       "title": str,
+       "totalCount": int
+    }
+
+    :rtype: dict
+    """
+
+    # see if there are any data tags inside the response
+    data = json_response.get('data')
+    if data is None or len(data) == 0:
+        return
+
+    for data_point in data:
+        yield data_point
+
+
+def _camel_to_snake_case(string: str) -> str:
+    """
+    converts camelCase to snake_case.
+    snake_case is used for metric names.
+    camelCase is used for endpoint names.
+
+    :rtype: str
+    """
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', string)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
+def sigterm_handler(_signo, _stack_frame):
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    # Ensure we have something to export
+    start_http_server(int(os.getenv('BIND_PORT', 9170)))
+    REGISTRY.register(DDFCollector())
+
+    signal.signal(signal.SIGTERM, sigterm_handler)
+    while True:
+        time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+prometheus-client
+requests

--- a/test/test_ddf_exporter.py
+++ b/test/test_ddf_exporter.py
@@ -1,0 +1,358 @@
+import unittest
+from unittest.mock import patch, call
+import os
+import ddf_exporter
+import prometheus_client
+
+
+class TestDdfExporter(unittest.TestCase):
+
+    def _set_env_var(self, var: str, value):
+        os.environ[var] = value
+
+    def _reset_env_var(self, var, previous_value=None):
+        if previous_value is None:
+            # del is platform independent
+            del os.environ[var]
+        else:
+            os.environ[var] = previous_value
+
+    def setUp(self):
+        # env vars for the test
+        self.metric_prefix = 'test_case_'
+        self.host = 'https://localhost'
+
+        # env vars previous to the test
+        self.old_metric_prefix = os.getenv('METRIC_PREFIX')
+        self.old_host = os.getenv('HOST_ADDRESS')
+
+        # set the env vars to the test ones
+        self._set_env_var('METRIC_PREFIX', self.metric_prefix)
+        self._set_env_var('HOST_ADDRESS', self.host)
+
+    def tearDown(self):
+
+        # set the env vars to whatever they were before the tests,
+        # if they were None, just unset them.
+        self._reset_env_var('METRIC_PREFIX', previous_value=self.old_metric_prefix)
+
+        self._reset_env_var('HOST_ADDRESS', previous_value=self.old_host)
+
+
+    def mocked_requests_session_get(*args, **kwargs):
+
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+        if args[0] == 'https://localhost:8993/services/internal/metrics/':
+            return MockResponse({'title': 'categoryQueries'}, 200)
+
+        elif args[0] == 'https://localhost:8993/services/internal/metrics/testMetric.json?dateOffset=120':
+            return MockResponse({'value': 0.0}, 200)
+
+        elif args[0] == 'https://localhost:8993/services/internal/metrics/connectionError.json?dateOffset=120':
+            return MockResponse({}, 403)
+
+        return MockResponse(None, 404)
+
+
+    @patch('requests.Session.get', side_effect=mocked_requests_session_get)
+    def test__make_request_insecure(self, mock_get):
+
+        os.environ['SECURE'] = "False"
+
+        exp = ddf_exporter.DDFCollector()
+
+        # test_acquire_endpoints_request
+        json_data = exp._make_request('', offset=None)
+        self.assertEqual(json_data, {'title': 'categoryQueries'}, 200)
+
+        # test_successful_request
+        exp.metric_endpoints['test_metric'] = 'testMetric'
+        json_data = exp._make_request('test_metric')
+        self.assertEqual(json_data, {'value': 0.0}, 200)
+
+        # test_site_not_found_request
+        exp.metric_endpoints['not_found_metric'] = 'notFoundMetric'
+        json_data = exp._make_request('not_found_metric')
+        self.assertIsNone(json_data)
+
+        # test_no_data_field_response
+        exp.metric_endpoints['connection_error'] = 'connectionError'
+        json_data = exp._make_request('connection_error')
+        self.assertDictEqual(json_data, {})
+
+
+    @patch('requests.Session.get', side_effect=mocked_requests_session_get)
+    @patch('os.path.isfile', return_value=True)
+    def test__make_request_secure(self, mock_get, mock_os):
+
+        os.environ['SECURE'] = "True"
+
+        exp = ddf_exporter.DDFCollector()
+
+        # test_acquire_endpoints_request
+        json_data = exp._make_request('', offset=None)
+        self.assertEqual(json_data, {'title': 'categoryQueries'}, 200)
+
+        # test_successful_request
+        exp.metric_endpoints['test_metric'] = 'testMetric'
+        json_data = exp._make_request('test_metric')
+        self.assertEqual(json_data, {'value': 0.0}, 200)
+
+        # test_site_not_found_request
+        exp.metric_endpoints['not_found_metric'] = 'notFoundMetric'
+        json_data = exp._make_request('not_found_metric')
+        self.assertIsNone(json_data)
+
+        # test_no_data_field_response
+        exp.metric_endpoints['connection_error'] = 'connectionError'
+        json_data = exp._make_request('connection_error')
+        self.assertDictEqual(json_data,{})
+
+
+    @patch('requests.Session.get', side_effect=mocked_requests_session_get)
+    @patch('os.path.isfile', return_value=False)
+    def test__make_request_secure_no_file(self, mock_get, mock_os):
+
+        os.environ['SECURE'] = "True"
+
+        exp = ddf_exporter.DDFCollector()
+
+        # test no cert response
+        self.assertRaises(FileNotFoundError, exp._make_request, 'connection_error')
+
+
+    def test__json_to_metric_generator(self):
+
+        # test empty dict
+        gen = ddf_exporter._json_to_metric_generator({})
+        self.assertRaises(StopIteration, next, gen)
+
+        # test dict with no data attribute
+        gen = ddf_exporter._json_to_metric_generator({'title': 'Empty'})
+        self.assertRaises(StopIteration, next, gen)
+
+        # test dict with 1 result
+        gen = ddf_exporter._json_to_metric_generator({
+                'title': '1data',
+                'data': [{'value': 0.0, 'timestamp': 'Jan 15 2019 12:07:00'}]})
+
+        self.assertDictEqual(next(gen), {'value': 0.0, 'timestamp': 'Jan 15 2019 12:07:00'})
+
+        self.assertRaises(StopIteration, next, gen)
+
+        # test dict with multiple results
+        gen = ddf_exporter._json_to_metric_generator({
+            'title': '1data',
+            'data': [{'value': 0.0, 'timestamp': 'Jan 15 2019 12:07:00'},
+                    {'value': 0.3, 'timestamp': 'Jan 15 2019 12:08:00'}]
+        })
+
+        self.assertDictEqual(next(gen), {'value': 0.0, 'timestamp': 'Jan 15 2019 12:07:00'})
+        self.assertDictEqual(next(gen), {'value': 0.3, 'timestamp': 'Jan 15 2019 12:08:00'})
+
+        self.assertRaises(StopIteration, next, gen)
+
+
+    def test_fetch_available_endpoints(self):
+
+        # test with no responses
+        with patch.object(ddf_exporter.DDFCollector, '_make_request', return_value={}) as mock_make_request:
+            exp = ddf_exporter.DDFCollector()
+            self.assertDictEqual(exp.fetch_available_endpoints(), {})
+
+        # test with 1 response
+        with patch.object(ddf_exporter.DDFCollector, '_make_request', return_value={'fakeItemA': 'a'}) as mock_make_request:
+            exp = ddf_exporter.DDFCollector()
+            self.assertDictEqual(exp.fetch_available_endpoints(), {'fake_item_a': 'fakeItemA'})
+
+        # Test with multiple responses
+        with patch.object(ddf_exporter.DDFCollector, '_make_request', return_value={'fakeItemA': 'a', 'fakeItemB': 'b'}) as mock_make_request:
+            exp = ddf_exporter.DDFCollector()
+            self.assertDictEqual(exp.fetch_available_endpoints(), {'fake_item_a': 'fakeItemA', 'fake_item_b': 'fakeItemB'})
+
+
+    def mocked_make_request(*args, **kwargs):
+
+        options = {
+            'empty': {},
+            'no_label': {'data': [{'value': 0.0}]},
+            'yes_label': {'data': [{'value': 1.0}]},
+            '1_0': {'data': []},
+            '1_1': {'data': [{'value': 1.0}]},
+            '1_2': {'data': [{'value': 1.0},
+                             {'value': 2.0}]},
+            '2_0_metric_1': {'data': []},
+            '2_0_metric_2': {'data': []},
+            '2_1_metric_1': {'data': [{'value': 1.0}]},
+            '2_1_metric_2': {'data': [{'value': 2.0}]},
+            '2_2_metric_1': {'data': [{'value': 1.0},
+                             {'value': 2.0}]},
+            '2_2_metric_2': {'data': [{'value': 1.0},
+                             {'value': 2.0}]}
+        }
+
+        return options.get(args[0], 'no value found')
+
+
+    @patch('ddf_exporter.DDFCollector._make_request', side_effect=mocked_make_request)
+    def test_populate_and_fetch_metrics(self, mock_requests):
+
+        exp = ddf_exporter.DDFCollector()
+
+        # test empty dict
+        metrics = exp.populate_and_fetch_metrics({}, self.metric_prefix)
+        self.assertDictEqual(metrics, {})
+
+        # test metric without labels
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily,'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'no_label': 'no_label'},
+                                            self.metric_prefix)
+
+        mock_add_metric.assert_called_with(labels=[], value=0.0)
+
+        # test metric with labels
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily,'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'yes_label': 'yes_label'},
+                                            self.metric_prefix,
+                                            {'host_label': 'machine_yes_label'})
+
+        mock_add_metric.assert_called_with(labels=['machine_yes_label'], value=1.0)
+
+        # test 1 metric; 0 sample
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily, 'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'1_0': '1_0'},
+                                            self.metric_prefix,
+                                            {'host_label': 'machine_1_0'})
+
+        mock_add_metric.assert_not_called()
+
+        # test 1 metric; 1 sample
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily, 'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'1_1': '1_1'},
+                                            self.metric_prefix,
+                                            {'host_label': 'machine_1_1'})
+
+        mock_add_metric.assert_called_with(labels=['machine_1_1'], value=1.0)
+
+        # test 1 metric; multiple samples
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily, 'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'1_2': '1_2'},
+                                            self.metric_prefix,
+                                            {'host_label': 'machine_1_2'})
+
+        calls = [call(labels=['machine_1_2'], value=1.0), call(labels=['machine_1_2'], value=2.0)]
+        mock_add_metric.assert_has_calls(calls)
+
+        # test multiple metric; 0 sample
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily, 'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'2_0_metric_1': '2_0_metric_1',
+                                            '2_0_metric_2': '2_0_metric_2'},
+                                            self.metric_prefix,
+                                            {'host_label': 'machine_2_0'})
+
+        mock_add_metric.assert_not_called()
+
+        # test multiple metric; 1 sample
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily, 'add_metric') as mock_add_metric:
+            exp.populate_and_fetch_metrics({'2_1_metric_1': '2_1_metric_1',
+                                            '2_1_metric_2': '2_1_metric_2'},
+                                            self.metric_prefix,
+                                            {'host_label': 'machine_2_1'})
+
+        calls = [call(labels=['machine_2_1'], value=1.0), call(labels=['machine_2_1'], value=2.0)]
+        mock_add_metric.assert_has_calls(calls)
+        # Its hard to tell because we are patching the add_metric method, but the metric_results would end up looking
+        # similar to:
+        # {
+        #  '2_1_metric_1':
+        # 	Metric(test_case_2_1_metric_1, ...,
+        # 		[Sample(name='test_case_2_1_metric_1',
+        # 				labels={'host_label': 'machine_2_1'},
+        # 				value=1.0)
+        # 		]
+        # 	),
+        #  '2_1_metric_2':
+        # 	Metric(test_case_2_1_metric_2, ...,
+        # 		[Sample(name='test_case_2_1_metric_2',
+        # 				labels={'host_label': 'machine_2_1'},
+        # 				value=2.0)
+        # 		]
+        # 	)
+        # }
+
+        # test multiple metric; multiple samples
+        with patch.object(prometheus_client.metrics_core.GaugeMetricFamily, 'add_metric') as mock_add_metric:
+            metrics = exp.populate_and_fetch_metrics({'2_2_metric_1': '2_2_metric_1',
+                                                      '2_2_metric_2': '2_2_metric_2'},
+                                                     self.metric_prefix,
+                                                     {'host_label': 'machine_2_2'})
+
+        calls = [call(labels=['machine_2_2'], value=1.0),
+                 call(labels=['machine_2_2'], value=2.0),
+                 call(labels=['machine_2_2'], value=1.0),
+                 call(labels=['machine_2_2'], value=2.0)]
+        mock_add_metric.assert_has_calls(calls)
+        # {
+        # '2_2_metric_1':
+        #     Metric(test_case_2_2_metric_1, ...,
+        #            [Sample(name='test_case_2_2_metric_1',
+        #                    labels={'host_label': 'machine_2_1'},
+        #                    value=1.0),
+        #             Sample(name='test_case_2_2_metric_1',
+        #                    labels={'host_label': 'machine_2_1'},
+        #                    value=2.0)
+        #             ]
+        #     ),
+        # '2_2_metric_2':
+        #     Metric(test_case_2_2_metric_2, ...,
+        #            [Sample(name='test_case_2_2_metric_2',
+        #                    labels={'host_label': 'machine_2_1'},
+        #                    value=1.0),
+        #             Sample(name='test_case_2_2_metric_2',
+        #                    labels={'host_label': 'machine_2_1'}
+        #                    value = 2.0)
+        #             ]
+        #     )
+        # }
+
+    def test__camel_to_snake_case(self):
+
+        # test empty string
+        ans = ddf_exporter._camel_to_snake_case('')
+        self.assertEqual(ans, '')
+
+        # test camel case string
+        ans = ddf_exporter._camel_to_snake_case('camelCaseString')
+        self.assertEqual(ans, 'camel_case_string')
+
+        # test upper camel case string
+        ans = ddf_exporter._camel_to_snake_case('CamelCaseString')
+        self.assertEqual(ans, 'camel_case_string')
+
+        # test snake case string
+        ans = ddf_exporter._camel_to_snake_case('snake_case_string')
+        self.assertEqual(ans, 'snake_case_string')
+
+        # test numbers in string
+        ans = ddf_exporter._camel_to_snake_case('a1B2c34D')
+        self.assertEqual(ans, 'a1_b2c34_d')
+
+        # test all caps string
+        ans = ddf_exporter._camel_to_snake_case('consecutiveUPPERCase')
+        self.assertEqual(ans, 'consecutive_upper_case')
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
### Description of the Change
This PR represents an exporter designed to translate from the DDF metrics endpoint to a prometheus metrics backend. It runs in a docker container, registers itself with a running prometheus instance, and exposes its metrics on the specified port at any endpoint. It uses the python prometheus-client library to provide the translation to prometheus metrics. All metrics are tagged with the host from which they originated.

Methods are doc-string'd and any assumptions or design decisions are documented within the code as well. It can be configured by environment variables (see readme). Secure connections using a cacert (.pem) are the default, but the cert must be provided at the path specified in the corresponding environment variable.

The exporter also dynamically fetches, generates, and populates the available metrics from the endpoint. If metrics are added to/removed from the DDF metric endpoint, they will automatically be handled by the exporter without requiring changes.

### Verification Process
* Created unit-tests using python's test/mock facilities to verify functionality.
* Tested the various operation modes; namely http connections, insecure https connections, and secure connections with/without providing a cert. 

### Hero instructions
1. Set up a DDF instance and a prometheus instance.
2. Build the ddf_exporter docker image and configure the environment variables to your particular setups of DDF and prometheus.
3. Generate some metrics. EX: searching in Intrigue will generate data for the catalog_queries metric.
4. Locate the metric inside the prometheus instance. EX: Using the example above with the defaults it will be called `ddf_catalog_queries`.
5. Verify the value corresponds to the number of searches made, and also that it changes as the searches cease. It may take between 1-2 minutes for metric values to update. 

<!--
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
-->

### Review
@oconnormi 
