### PR TITLE
Added hostname and sitename to labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This exporter can be configured using environment variables, they are as follows
 | `METRIC_PREFIX` | "ddf_" | What to prepend to all of the gathered metrics
 | `HOST_ADDRESS` | "https://localhost" | The address to gather metrics from. Please include the http:// or https://
 | `HOST_PORT` | 8993 | The port to gather metrics from
+| `SITE_NAME` | The host address without http:// or https:// | The name for the DDF instance that is providing metrics
 | `METRIC_API_LOCATION` | "services/internal/metrics" | The path to the metrics endpoint
 | `SECURE` | "True" | Whether to use ssl for the connection. <br/> If true, you must point to a valid ca cert in the next parameter
 | `CA_CERT_PATH` | "/certs/ca.pem" | The path to the ca cert to be used during secure connections
@@ -34,6 +35,7 @@ This exporter can be configured using environment variables, they are as follows
           BIND_PORT: 9170
           HOST_ADDRESS: "https://localhost"
           HOST_PORT: 8993
+          SITE_NAME: "My local DDF"
           METRIC_PREFIX: "ddf_"
           METRIC_API_LOCATION: "services/internal/metrics"
           SECURE: "True"

--- a/ddf_exporter.py
+++ b/ddf_exporter.py
@@ -14,7 +14,7 @@ class DDFCollector:
 
         self.metric_prefix = os.getenv('METRIC_PREFIX', 'ddf_')
         self.host = os.getenv('HOST_ADDRESS', 'https://localhost')
-        self.hostname = self.host.split('://')[1]
+        self.hostname = self.host.split('://')[-1]
         self.sitename = os.getenv('SITE_NAME', self.hostname)
         self.host_port = os.getenv('HOST_PORT', 8993)
         self.metric_api_location = os.getenv('METRIC_API_LOCATION',

--- a/ddf_exporter.py
+++ b/ddf_exporter.py
@@ -15,6 +15,7 @@ class DDFCollector:
         self.metric_prefix = os.getenv('METRIC_PREFIX', 'ddf_')
         self.host = os.getenv('HOST_ADDRESS', 'https://localhost')
         self.hostname = self.host.split('://')[1]
+        self.sitename = os.getenv('SITE_NAME', self.hostname)
         self.host_port = os.getenv('HOST_PORT', 8993)
         self.metric_api_location = os.getenv('METRIC_API_LOCATION',
                                              'services/internal/metrics')
@@ -35,7 +36,7 @@ class DDFCollector:
         self.metric_results = self.populate_and_fetch_metrics(
             self.metric_endpoints,
             self.metric_prefix,
-            labels={'host': self.host, 'hostname': self.hostname})
+            labels={'host': self.host, 'hostname': self.hostname, 'sitename': self.sitename})
 
         # yield the data as metrics
         for metric_name in self.metric_endpoints.keys():

--- a/ddf_exporter.py
+++ b/ddf_exporter.py
@@ -14,6 +14,7 @@ class DDFCollector:
 
         self.metric_prefix = os.getenv('METRIC_PREFIX', 'ddf_')
         self.host = os.getenv('HOST_ADDRESS', 'https://localhost')
+        self.hostname = self.host.split('://')[1]
         self.host_port = os.getenv('HOST_PORT', 8993)
         self.metric_api_location = os.getenv('METRIC_API_LOCATION',
                                              'services/internal/metrics')
@@ -34,7 +35,7 @@ class DDFCollector:
         self.metric_results = self.populate_and_fetch_metrics(
             self.metric_endpoints,
             self.metric_prefix,
-            labels={'host': self.host})
+            labels={'host': self.host, 'hostname': self.hostname})
 
         # yield the data as metrics
         for metric_name in self.metric_endpoints.keys():


### PR DESCRIPTION
#### What does this PR do?
It adds hostname and sitename to the labels.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@oconnormi 
@aperullo 

#### How should this be tested? (List steps with links to updated documentation)
Run DDF and the exporter and ensure that the data now has a hostname and sitename label in Prometheus.
Check that the hostname is the same as host but stripped of the http:// or https://
Check that the sitename is set by the SITE_NAME environment variable, and defaults to the hostname if no environment variable is set.

#### Any background context you want to provide?
This will be used to improve Grafana dashboards that use these metrics.
